### PR TITLE
Fix bug with deploy

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -66,10 +66,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2
-        with:
-          name: |
-            backend
-            frontend
       - uses: a-was/scp-files-action@v1
         with:
           host: ${{ secrets.REMOTE_HOST }}


### PR DESCRIPTION
You can't specify multiple artifact names to download, but if you don't specify, it downloads them all by default