### PR TITLE
Fix container shutdown—always cleanly shutdown

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -159,7 +159,11 @@ jobs:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: ln -snf ~/builds/${{ github.event.pull_request.head.sha }} ~/climate-risk-map && podman restart crm_backend
+          script: >
+            podman stop crm_backend &&
+            ln -snf ~/builds/${{ github.event.pull_request.head.sha }} ~/climate-risk-map &&
+            podman run --rm -v ~/climate-risk-map/backend:/opt/climate-risk-map/backend:Z --tz=America/New_York --env-file=~/.env --pod=crm_pod sqlx migrate run &&
+            podman start crm_backend
 
   deploy-production:
     if: github.event_name == 'push'
@@ -194,4 +198,8 @@ jobs:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: podman stop crm_backend && ln -snf ~/builds/${{ github.sha }} ~/climate-risk-map && podman start crm_backend
+          script: >
+            podman stop crm_backend &&
+            ln -snf ~/builds/${{ github.sha }} ~/climate-risk-map &&
+            podman run --rm -v ~/climate-risk-map/backend:/opt/climate-risk-map/backend:Z --tz=America/New_York --env-file=~/.env --pod=crm_pod sqlx migrate run &&
+            podman start crm_backend

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -162,7 +162,7 @@ jobs:
           script: >
             podman stop crm_backend &&
             ln -snf ~/builds/${{ github.event.pull_request.head.sha }} ~/climate-risk-map &&
-            podman run --rm -v ~/climate-risk-map/backend:/opt/climate-risk-map/backend:Z --tz=America/New_York --env-file=~/.env --pod=crm_pod sqlx migrate run &&
+            podman run --rm -v ~/climate-risk-map/backend:/opt/climate-risk-map/backend:Z --tz=America/New_York --env-file=$HOME/.env --pod=crm_pod sqlx migrate run &&
             podman start crm_backend
 
   deploy-production:
@@ -201,5 +201,5 @@ jobs:
           script: >
             podman stop crm_backend &&
             ln -snf ~/builds/${{ github.sha }} ~/climate-risk-map &&
-            podman run --rm -v ~/climate-risk-map/backend:/opt/climate-risk-map/backend:Z --tz=America/New_York --env-file=~/.env --pod=crm_pod sqlx migrate run &&
+            podman run --rm -v ~/climate-risk-map/backend:/opt/climate-risk-map/backend:Z --tz=America/New_York --env-file=$HOME/.env --pod=crm_pod sqlx migrate run &&
             podman start crm_backend


### PR DESCRIPTION
Morgan is splitting out the containers into two parts

- `crm_backend`
- `sqlx`

Previously the `crm_backend` container [ran the database migration and then the `climate_risk_map` service](https://github.com/mjbludwig/climate_risk_map_builder/blob/da9ac4b083930f26bc68a6df5b06447d0dfdd293/make_crm_backend.sh#L8) from within `sh` as the entrypoint. This prevented the container from sending a `SIGTERM` to the service to cleanly shut it down, so it was hard-killing it with `SIGKILL` (after a 10 second timeout) every time we restarted it.

When the container only runs a single command, it doesn't need the `sh`, which allows it to send the `SIGTERM`.

See https://github.com/cypressf/mit-climate-data-viz/issues/251#issuecomment-1030362149