### PR TITLE
Only show http requests in logs

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -19,8 +19,10 @@ async fn main() -> std::io::Result<()> {
         connections: Mutex::new(0),
         database: Arc::new(editor_database),
     });
-    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
-
+    env_logger::Builder::from_env(
+        Env::default().default_filter_or("actix_web=info,actix_server=info"),
+    )
+    .init();
     let read_only_app = HttpServer::new(move || {
         App::new()
             .app_data(app_state.clone())


### PR DESCRIPTION
They were so full of database query logs they were hard to read. If we really want to see details about every database query, we can enable them temporarily by running the container with the environment variable `RUST_LOG=info` or `RUST_LOG=debug` for even more verbosity.

See https://docs.rs/env_logger/0.6.1/env_logger/