### PR TITLE
Make editor tabs bookmarkable too

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ function App() {
             <Routes>
                 <Route path="/uploader" element={<Uploader />} />
                 <Route path="/editor" element={<Editor />} />
+                <Route path="/editor/:tabId" element={<Editor />} />
                 <Route path="/" element={<Home />} />
                 <Route path="/:tabId" element={<Home />} />
                 <Route

--- a/frontend/src/DataTab.ts
+++ b/frontend/src/DataTab.ts
@@ -1,4 +1,4 @@
-export enum DataTab {
+enum DataTab {
     RiskMetrics = 'combined data',
     Water = 'water',
     Land = 'land',

--- a/frontend/src/FullMap.tsx
+++ b/frontend/src/FullMap.tsx
@@ -4,7 +4,7 @@ import BubbleMap from './BubbleMap'
 import ChoroplethMap from './ChoroplethMap'
 import { TopoJson } from './TopoJson'
 import { MapType, MapVisualization, TabToId } from './MapVisualization'
-import { DataTab } from './DataTab'
+import DataTab from './DataTab'
 
 export const getUnitString = (units: string) => (units ? ` ${units}` : '')
 

--- a/frontend/src/MapApi.ts
+++ b/frontend/src/MapApi.ts
@@ -58,7 +58,7 @@ const transformData = (
 export const mapApi = createApi({
     reducerPath: 'mapApi',
     keepUnusedDataFor: 5 * 60, // 5 minutes
-    baseQuery: fetchBaseQuery({ baseUrl: 'api/' }),
+    baseQuery: fetchBaseQuery({ baseUrl: '/api/' }),
     tagTypes: ['MapVisualization'],
     endpoints: (builder) => ({
         getData: builder.query<DataByDataset, DataQueryParams[]>({
@@ -66,7 +66,7 @@ export const mapApi = createApi({
                 const loadingCsvs = queryParams.map(
                     async ({ dataset, source, startDate, endDate }) => {
                         const csvRow = await loadCsv<CsvRow>(
-                            `api/data/${dataset}?source=${source}&start_date=${startDate}&end_date=${endDate}`,
+                            `/api/data/${dataset}?source=${source}&start_date=${startDate}&end_date=${endDate}`,
                             autoType
                         )
                         return [dataset, csvRow] as [number, DSVParsedArray<CsvRow>]

--- a/frontend/src/MapVisualization.ts
+++ b/frontend/src/MapVisualization.ts
@@ -231,7 +231,7 @@ export const getDataQueryParams = (mapVisualization: MapVisualization): DataQuer
 }
 
 export const fetchMapVisualization = async (id: number): Promise<MapVisualization> => {
-    const rawJson = await loadJson<MapVisualizationJson>(`api/map-visualization/${id}`)
+    const rawJson = await loadJson<MapVisualizationJson>(`/api/map-visualization/${id}`)
     if (rawJson === undefined) {
         return Promise.reject(new Error('Failed to fetch map visualization'))
     }
@@ -240,7 +240,7 @@ export const fetchMapVisualization = async (id: number): Promise<MapVisualizatio
 
 export const fetchMapVisualizations = async (): Promise<MapVisualizationByTabId> => {
     const rawJson = await loadJson<{ [key: number]: { [key: number]: MapVisualizationJson } }>(
-        'api/map-visualization'
+        '/api/map-visualization'
     )
     if (rawJson === undefined) {
         return Promise.reject(new Error('Failed to fetch map visualizations'))

--- a/frontend/src/editor/editorSlice.ts
+++ b/frontend/src/editor/editorSlice.ts
@@ -1,28 +1,39 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import DataTab from '../DataTab'
 import { Tab } from '../MapApi'
 import { MapVisualization, MapVisualizationId } from '../MapVisualization'
 import { RootState } from '../store'
 import { TopoJson } from '../TopoJson'
 
 interface EditorState {
-    readonly selectedTabId?: number
+    readonly selectedTabId?: DataTab
     readonly tabs: Tab[]
-    readonly selectedMapVisualizationByTab: { [key: number]: MapVisualizationId }
+    readonly selectedMapVisualizationByTab: { [key in DataTab]: MapVisualizationId }
     readonly map?: TopoJson
 }
 
 const initialState: EditorState = {
     tabs: [],
-    selectedTabId: 8,
-    selectedMapVisualizationByTab: { 8: 2 },
+    selectedTabId: DataTab.RiskMetrics,
+    selectedMapVisualizationByTab: {
+        [DataTab.RiskMetrics]: 71,
+        [DataTab.Water]: 1,
+        [DataTab.Land]: 15,
+        [DataTab.Climate]: 22,
+        [DataTab.Economy]: 12,
+        [DataTab.Demographics]: 28,
+        [DataTab.ClimateOpinions]: 35,
+        [DataTab.Energy]: 64,
+        [DataTab.Health]: 71,
+    },
 }
 
 export const editorSlice = createSlice({
     name: 'editor',
     initialState,
     reducers: {
-        clickTab(state, { payload }: PayloadAction<Tab>) {
-            state.selectedTabId = payload.id
+        setTab(state, { payload }: PayloadAction<DataTab>) {
+            state.selectedTabId = payload
         },
         setMap(state, { payload }: PayloadAction<TopoJson>) {
             state.map = payload
@@ -35,7 +46,7 @@ export const editorSlice = createSlice({
     },
 })
 
-export const { clickTab, setMap, clickMapVisualization } = editorSlice.actions
+export const { setTab, setMap, clickMapVisualization } = editorSlice.actions
 
 export const selectSelectedTabAndMapVisualization = (state: RootState) => {
     const { selectedTabId } = state.editor


### PR DESCRIPTION
Each editor tab now has its own url, just like the map visualization tabs.

It's a bit hacky to use absolute paths /editor/{id} in all the editor tab links. I should try to figure out a way to make them relative without stacking /editor/{id}/{id}