### PR TITLE
Fix crash when viewing the Uncategorized tab

### DIFF
--- a/frontend/src/editor/Editor.tsx
+++ b/frontend/src/editor/Editor.tsx
@@ -90,7 +90,9 @@ function Editor() {
     )
     const mapVisualizationsForTab =
         allMapVisualizations && selectedTabId !== undefined
-            ? Object.values(allMapVisualizations[selectedTabId]).sort((a, b) => a.order - b.order)
+            ? Object.values(allMapVisualizations[selectedTabId] ?? []).sort(
+                  (a, b) => a.order - b.order
+              )
             : undefined
     const map = useSelector((state: RootState) => state.editor.map)
 


### PR DESCRIPTION
The tab doesn't exist in the object, so we get an undefined exception instead of empty list.