### PR TITLE
Change default date for water stress

### DIFF
--- a/backend/migrations/20220228193035_change-default-date.sql
+++ b/backend/migrations/20220228193035_change-default-date.sql
@@ -1,0 +1,7 @@
+UPDATE
+    map_visualization
+SET
+    default_start_date = '2010-01-01',
+    default_end_date = '2015-12-31'
+WHERE
+    dataset = 1;


### PR DESCRIPTION
It was showing 1995 on the homepage under risk metrics. Fixes https://github.com/cypressf/mit-climate-data-viz/issues/267