### PR TITLE
Do not show map visualization if it's not in tab

### DIFF
--- a/frontend/src/editor/Editor.tsx
+++ b/frontend/src/editor/Editor.tsx
@@ -82,11 +82,8 @@ function Editor() {
     const { data: tabs } = useGetTabsQuery(true)
     const [createMap] = useCreateMapVisualizationMutation()
 
-    const { selectedTabId, selectedMapVisualizationId } = useSelector(
+    const { selectedTabId, selectedMapVisualizationId: maybeSelectedMap } = useSelector(
         selectSelectedTabAndMapVisualization
-    )
-    const { data: selectedMapVisualization } = useGetMapVisualizationQuery(
-        selectedMapVisualizationId ?? skipToken
     )
     const mapVisualizationsForTab =
         allMapVisualizations && selectedTabId !== undefined
@@ -94,6 +91,12 @@ function Editor() {
                   (a, b) => a.order - b.order
               )
             : undefined
+    const selectedMap = mapVisualizationsForTab?.find((m) => m.id === maybeSelectedMap)
+        ? maybeSelectedMap
+        : undefined
+    const { data: selectedMapVisualization, isUninitialized } = useGetMapVisualizationQuery(
+        selectedMap ?? skipToken
+    )
     const map = useSelector((state: RootState) => state.editor.map)
 
     useEffect(() => {
@@ -116,7 +119,7 @@ function Editor() {
                         <>
                             <MapVisualizationList
                                 mapVisualizations={mapVisualizationsForTab}
-                                selectedId={selectedMapVisualizationId}
+                                selectedId={selectedMap}
                                 onClick={(clickedMap) =>
                                     dispatch(clickMapVisualization(clickedMap))
                                 }
@@ -138,12 +141,12 @@ function Editor() {
                 {map && (
                     <EditorMap
                         map={map}
-                        selection={selectedMapVisualization}
+                        selection={isUninitialized ? undefined : selectedMapVisualization}
                         detailedView
                         isNormalized={isNormalized}
                     />
                 )}
-                {selectedMapVisualization && !isNormalized ? (
+                {!isUninitialized && selectedMapVisualization && !isNormalized ? (
                     <MapOptions mapVisualization={selectedMapVisualization} />
                 ) : (
                     <EmptyMapOptions />


### PR DESCRIPTION
When switching tabs, we would show the map visualization that was selected from the previous tab before the new tab loaded anything. This was bad because if the new tab had no map visualizations, or a bad default map visualization, it would allow someone to edit a map visualization in a different tab.

For example. if you opened risk metrics, then opened "uncategorized" you would still see the map you had selected in risk metrics, because "uncategorized" had no map selected. This allowed someone to edit a risk metrics map when viewing the uncategorized tab.

The map visualization request `isUninitialized` when the skip token gets passed in.