### PR TITLE
Fix issue where glibc doesn't match prod env

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build-backend:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       SQLX_VERSION: ^0.6.2
@@ -83,7 +83,7 @@ jobs:
           path: backend/backend.tar
 
   build-frontend:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -128,7 +128,7 @@ jobs:
       name: development
       url: https://svante3.mit.edu
     needs: [build-backend, build-frontend]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -168,7 +168,7 @@ jobs:
       name: production
       url: https://est.mit.edu
     needs: [build-backend, build-frontend]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
The newer version of ubuntu-latest (22.04) was using a version of glibc when compiling the rust binary that made it unrunnable on our dev server's environment.