### PR TITLE
Remove feedback button

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,13 +10,6 @@
     landscapes of socio-economic, health, and environmental risk and injustice." />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
-    <script async src="https://w.appzi.io/w.js?token=UtGNw"></script>
-
-    <style>
-        [id*='appzi'] {
-            z-index: 10000 !important;
-        }
-    </style>
     <title>Socio-Environmental Systems Risk Triage</title>
 </head>
 


### PR DESCRIPTION
1. No one knows where the dashboard with the feedback has gone. Appzi changed since I was last on the project and logging in no longer shows it.
2. We are going to replace it with a generic email address to contact this project. @azzacasch will create it
3. The feedback button negatively impacts load times of the page. It loads a third party script and a custom web font. Nothing blocking, but it's good to be efficient with these things when we don't need them.

# Before

Yellow feedback button visible

<img width="827" height="795" alt="Screenshot 2026-07-27 at 15 55 22" src="https://github.com/user-attachments/assets/cefb0198-2631-4bbb-8b4b-b3d6479d8893" />


# After 

No more!

<img width="686" height="773" alt="Screenshot 2026-07-27 at 15 53 38" src="https://github.com/user-attachments/assets/52824eb9-c79f-4007-a1ee-6871688e818e" />
