### PR TITLE
Fix dataset deletion when draft map visualizations exist

### DIFF
--- a/backend/src/dao/map_visualization_dao.rs
+++ b/backend/src/dao/map_visualization_dao.rs
@@ -173,7 +173,7 @@ impl<'c> Table<'c, MapVisualization> {
     }
 
     pub async fn delete_by_dataset(&self, dataset_id: i32) -> Result<PgQueryResult, sqlx::Error> {
-        sqlx::query!("DELETE FROM map_visualization WHERE id = $1", dataset_id)
+        sqlx::query!("DELETE FROM map_visualization WHERE dataset = $1", dataset_id)
             .execute(&*self.pool)
             .await
     }

--- a/frontend/src/editor/DatasetEditor.tsx
+++ b/frontend/src/editor/DatasetEditor.tsx
@@ -27,30 +27,24 @@ function MapVisualizations({
 
     return (
         <div className={css.mapVisualizations}>
-            <p>
-                You cannot delete a dataset while published maps exist. Unpublish these if you want
-                to delete the dataset:
-            </p>
+            <p>Map visualizations that use this dataset:</p>
             <ul>
                 {Object.entries(mapVisualizations).map(([tabId, mapVisualizations]) =>
                     Object.values(mapVisualizations).map((mapVisualization) => (
                         <li key={`${tabId} ${mapVisualization.id}`}>
-                            <p>
-                                <a href={`/editor/${tabId}`} target="_blank" rel="noreferrer">
-                                    {tabName(tabs, Number(tabId))}
-                                </a>
+                            <a href={`/editor/${tabId}`} target="_blank" rel="noreferrer">
+                                {tabName(tabs, Number(tabId))}
                                 {' > '}
                                 {mapVisualization.displayName}
-                            </p>
+                            </a>
                             <Button
                                 className={css.publishButton}
-                                onClick={() => {
-                                    const id = {
+                                onClick={() =>
+                                    unpublish({
                                         map_visualization: mapVisualization.id,
                                         category: Number(tabId),
-                                    }
-                                    unpublish(id)
-                                }}
+                                    })
+                                }
                                 variant="contained"
                                 color="error"
                             >
@@ -60,6 +54,10 @@ function MapVisualizations({
                     ))
                 )}
             </ul>
+            <p>
+                You cannot delete a dataset while published maps exist. Unpublish them if you want
+                to delete the dataset.
+            </p>
         </div>
     )
 }

--- a/frontend/src/editor/DatasetEditor.tsx
+++ b/frontend/src/editor/DatasetEditor.tsx
@@ -27,24 +27,30 @@ function MapVisualizations({
 
     return (
         <div className={css.mapVisualizations}>
-            <p>Map visualizations that use this dataset:</p>
+            <p>
+                You cannot delete a dataset while published maps exist. Unpublish these if you want
+                to delete the dataset:
+            </p>
             <ul>
                 {Object.entries(mapVisualizations).map(([tabId, mapVisualizations]) =>
                     Object.values(mapVisualizations).map((mapVisualization) => (
                         <li key={`${tabId} ${mapVisualization.id}`}>
-                            <a href={`/editor/${tabId}`} target="_blank" rel="noreferrer">
-                                {tabName(tabs, Number(tabId))}
+                            <p>
+                                <a href={`/editor/${tabId}`} target="_blank" rel="noreferrer">
+                                    {tabName(tabs, Number(tabId))}
+                                </a>
                                 {' > '}
                                 {mapVisualization.displayName}
-                            </a>
+                            </p>
                             <Button
                                 className={css.publishButton}
-                                onClick={() =>
-                                    unpublish({
+                                onClick={() => {
+                                    const id = {
                                         map_visualization: mapVisualization.id,
                                         category: Number(tabId),
-                                    })
-                                }
+                                    }
+                                    unpublish(id)
+                                }}
                                 variant="contained"
                                 color="error"
                             >
@@ -54,10 +60,6 @@ function MapVisualizations({
                     ))
                 )}
             </ul>
-            <p>
-                You cannot delete a dataset while published maps exist. Unpublish them if you want
-                to delete the dataset.
-            </p>
         </div>
     )
 }


### PR DESCRIPTION
## What changed

`delete_by_dataset` in `map_visualization_dao.rs` ran `DELETE FROM map_visualization WHERE id = $1` with a *dataset* id instead of `WHERE dataset = $1`. As a result, deleting a dataset that had draft (unpublished) map visualizations left those drafts in place and then failed on the foreign key constraint when deleting the dataset row itself.

## Why

Dataset deletion is supposed to cascade: collection entries, map visualizations, data rows, then the dataset. The wrong WHERE clause broke the map-visualization step for any dataset with drafts.

## Notes for reviewers

- One-line fix; verified against a locally migrated database — `cargo check` (sqlx compile-time query validation) passes and the delete path was exercised end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)