### PR TITLE
Fix data-source deletion: clear default_source refs, run cascade in one transaction

### DIFF
--- a/backend/src/controller/data_source_controller.rs
+++ b/backend/src/controller/data_source_controller.rs
@@ -39,30 +39,12 @@ async fn get_all(app_state: web::Data<AppState<'_>>) -> impl Responder {
 
 #[delete("/data-source/{id}")]
 async fn delete(id: web::Path<i32>, app_state: web::Data<AppState<'_>>) -> Result<String, Error> {
-    let id = id.into_inner();
-    let mut transaction = app_state
+    app_state
         .database
         .data_source
-        .pool
-        .begin()
+        .delete_cascading(id.into_inner())
         .await
         .map_err(Error)?;
-    sqlx::query!(
-        "UPDATE map_visualization SET default_source = NULL WHERE default_source = $1",
-        id
-    )
-    .execute(&mut transaction)
-    .await
-    .map_err(Error)?;
-    sqlx::query!("DELETE FROM data WHERE source = $1", id)
-        .execute(&mut transaction)
-        .await
-        .map_err(Error)?;
-    sqlx::query!("DELETE FROM data_source WHERE id = $1", id)
-        .execute(&mut transaction)
-        .await
-        .map_err(Error)?;
-    transaction.commit().await.map_err(Error)?;
     Ok("deleted".to_string())
 }
 

--- a/backend/src/controller/data_source_controller.rs
+++ b/backend/src/controller/data_source_controller.rs
@@ -38,14 +38,17 @@ async fn get_all(app_state: web::Data<AppState<'_>>) -> impl Responder {
 }
 
 #[delete("/data-source/{id}")]
-async fn delete(id: web::Path<i32>, app_state: web::Data<AppState<'_>>) -> Result<String, Error> {
+async fn delete(
+    id: web::Path<i32>,
+    app_state: web::Data<AppState<'_>>,
+) -> Result<HttpResponse, Error> {
     app_state
         .database
         .data_source
         .delete_cascading(id.into_inner())
         .await
         .map_err(Error)?;
-    Ok("deleted".to_string())
+    Ok(HttpResponse::Ok().finish())
 }
 
 #[derive(Debug, Display)]
@@ -63,98 +66,169 @@ mod tests {
     use super::*;
     use crate::dao::Database;
     use crate::AppState;
+    use actix_web::http::StatusCode;
     use actix_web::{test, App};
-    use sqlx::{PgPool, Row};
+    use sqlx::PgPool;
     use std::sync::{Arc, Mutex};
 
-    #[sqlx::test]
-    async fn delete_clears_default_source_and_cascades(pool: PgPool) {
-        let source_id: i32 = sqlx::query(
+    struct Seed {
+        source_id: i32,
+        map_visualization_id: i32,
+    }
+
+    async fn seed(pool: &PgPool) -> Seed {
+        let source_id = sqlx::query!(
             "INSERT INTO data_source (name, description, link)
              VALUES ('src cascade test', 'test source', 'https://example.com')
-             RETURNING id",
+             RETURNING id"
         )
-        .fetch_one(&pool)
+        .fetch_one(pool)
         .await
         .unwrap()
-        .get("id");
+        .id;
 
-        let dataset_id: i32 = sqlx::query(
+        let dataset_id = sqlx::query!(
             "INSERT INTO dataset (short_name, name, description, units, geography_type)
              VALUES ('src_cascade_test', 'Src Cascade Test', 't', 't', 1)
-             RETURNING id",
+             RETURNING id"
         )
-        .fetch_one(&pool)
+        .fetch_one(pool)
         .await
         .unwrap()
-        .get("id");
+        .id;
 
-        let map_visualization_id: i32 = sqlx::query(
+        let map_visualization_id = sqlx::query!(
             "INSERT INTO map_visualization
                  (dataset, map_type, color_palette, scale_type, formatter_type, default_source)
              VALUES ($1, 1, 1, 2, 3, $2)
              RETURNING id",
+            dataset_id,
+            source_id
         )
-        .bind(dataset_id)
-        .bind(source_id)
-        .fetch_one(&pool)
+        .fetch_one(pool)
         .await
         .unwrap()
-        .get("id");
+        .id;
 
-        sqlx::query(
+        sqlx::query!(
             "INSERT INTO data (dataset, source, start_date, end_date, value, geography_type, id)
              SELECT $1, $2, '2020-01-01', '2020-12-31', 1.0, geography_type, id
              FROM geo_id LIMIT 1",
+            dataset_id,
+            source_id
         )
-        .bind(dataset_id)
-        .bind(source_id)
-        .execute(&pool)
+        .execute(pool)
         .await
         .unwrap();
 
+        Seed {
+            source_id,
+            map_visualization_id,
+        }
+    }
+
+    async fn call_delete(pool: &PgPool, source_id: i32) -> StatusCode {
         let app_state = web::Data::new(AppState {
             connections: Mutex::new(0),
             database: Arc::new(Database::from_pool(pool.clone())),
         });
         let app = test::init_service(App::new().app_data(app_state).configure(init_editor)).await;
-
         let request = test::TestRequest::delete()
             .uri(&format!("/data-source/{source_id}"))
             .to_request();
-        let response = test::call_service(&app, request).await;
-        assert!(
-            response.status().is_success(),
-            "expected success, got {}",
-            response.status()
-        );
+        test::call_service(&app, request).await.status()
+    }
 
-        let sources: i64 = sqlx::query("SELECT COUNT(*) AS count FROM data_source WHERE id = $1")
-            .bind(source_id)
-            .fetch_one(&pool)
-            .await
-            .unwrap()
-            .get("count");
-        assert_eq!(sources, 0, "data_source row should be deleted");
+    async fn source_count(pool: &PgPool, source_id: i32) -> i64 {
+        sqlx::query!(
+            r#"SELECT COUNT(*) AS "count!" FROM data_source WHERE id = $1"#,
+            source_id
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .count
+    }
 
-        let data_rows: i64 = sqlx::query("SELECT COUNT(*) AS count FROM data WHERE source = $1")
-            .bind(source_id)
-            .fetch_one(&pool)
-            .await
-            .unwrap()
-            .get("count");
-        assert_eq!(data_rows, 0, "data rows for the source should be deleted");
+    async fn data_count(pool: &PgPool, source_id: i32) -> i64 {
+        sqlx::query!(
+            r#"SELECT COUNT(*) AS "count!" FROM data WHERE source = $1"#,
+            source_id
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .count
+    }
 
-        let default_source: Option<i32> =
-            sqlx::query("SELECT default_source FROM map_visualization WHERE id = $1")
-                .bind(map_visualization_id)
-                .fetch_one(&pool)
-                .await
-                .unwrap()
-                .get("default_source");
+    async fn default_source(pool: &PgPool, map_visualization_id: i32) -> Option<i32> {
+        sqlx::query!(
+            "SELECT default_source FROM map_visualization WHERE id = $1",
+            map_visualization_id
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .default_source
+    }
+
+    #[sqlx::test]
+    async fn delete_clears_default_source_and_cascades(pool: PgPool) {
+        let seed = seed(&pool).await;
+
+        let status = call_delete(&pool, seed.source_id).await;
+        assert!(status.is_success(), "expected success, got {}", status);
+
         assert_eq!(
-            default_source, None,
+            source_count(&pool, seed.source_id).await,
+            0,
+            "data_source row should be deleted"
+        );
+        assert_eq!(
+            data_count(&pool, seed.source_id).await,
+            0,
+            "data rows for the source should be deleted"
+        );
+        assert_eq!(
+            default_source(&pool, seed.map_visualization_id).await,
+            None,
             "map visualization should remain with default_source cleared"
+        );
+    }
+
+    #[sqlx::test]
+    async fn delete_rolls_back_when_source_is_still_referenced(pool: PgPool) {
+        let seed = seed(&pool).await;
+        // A table the cascade doesn't know about, referencing data_source: the
+        // scenario that future_model created in 2023. Runtime queries because
+        // the table doesn't exist at compile time.
+        sqlx::query("CREATE TABLE blocker (source INT NOT NULL REFERENCES data_source(id))")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO blocker (source) VALUES ($1)")
+            .bind(seed.source_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let status = call_delete(&pool, seed.source_id).await;
+        assert!(status.is_server_error(), "expected error, got {}", status);
+
+        assert_eq!(
+            source_count(&pool, seed.source_id).await,
+            1,
+            "data_source should survive the failed delete"
+        );
+        assert_eq!(
+            data_count(&pool, seed.source_id).await,
+            1,
+            "data row deletion should be rolled back"
+        );
+        assert_eq!(
+            default_source(&pool, seed.map_visualization_id).await,
+            Some(seed.source_id),
+            "default_source should be rolled back"
         );
     }
 }

--- a/backend/src/controller/data_source_controller.rs
+++ b/backend/src/controller/data_source_controller.rs
@@ -2,6 +2,8 @@ use crate::model::data_source::Diff;
 
 use super::AppState;
 use actix_web::{delete, get, patch, web, HttpResponse, Responder};
+use derive_more::Display;
+use log::error;
 
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(get_all);
@@ -36,19 +38,141 @@ async fn get_all(app_state: web::Data<AppState<'_>>) -> impl Responder {
 }
 
 #[delete("/data-source/{id}")]
-async fn delete(id: web::Path<i32>, app_state: web::Data<AppState<'_>>) -> impl Responder {
+async fn delete(id: web::Path<i32>, app_state: web::Data<AppState<'_>>) -> Result<String, Error> {
     let id = id.into_inner();
-    let result = app_state.database.data.delete_by_source(id).await;
+    let mut transaction = app_state
+        .database
+        .data_source
+        .pool
+        .begin()
+        .await
+        .map_err(Error)?;
+    sqlx::query!(
+        "UPDATE map_visualization SET default_source = NULL WHERE default_source = $1",
+        id
+    )
+    .execute(&mut transaction)
+    .await
+    .map_err(Error)?;
+    sqlx::query!("DELETE FROM data WHERE source = $1", id)
+        .execute(&mut transaction)
+        .await
+        .map_err(Error)?;
+    sqlx::query!("DELETE FROM data_source WHERE id = $1", id)
+        .execute(&mut transaction)
+        .await
+        .map_err(Error)?;
+    transaction.commit().await.map_err(Error)?;
+    Ok("deleted".to_string())
+}
 
-    match result {
-        Err(_) => HttpResponse::NotFound().finish(),
-        Ok(_) => {
-            let result = app_state.database.data_source.delete(id).await;
+#[derive(Debug, Display)]
+struct Error(sqlx::Error);
 
-            match result {
-                Err(_) => HttpResponse::NotFound().finish(),
-                Ok(_) => HttpResponse::Ok().finish(),
-            }
-        }
+impl actix_web::error::ResponseError for Error {
+    fn error_response(&self) -> HttpResponse {
+        error!("{self}");
+        HttpResponse::build(self.status_code()).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dao::Database;
+    use crate::AppState;
+    use actix_web::{test, App};
+    use sqlx::{PgPool, Row};
+    use std::sync::{Arc, Mutex};
+
+    #[sqlx::test]
+    async fn delete_clears_default_source_and_cascades(pool: PgPool) {
+        let source_id: i32 = sqlx::query(
+            "INSERT INTO data_source (name, description, link)
+             VALUES ('src cascade test', 'test source', 'https://example.com')
+             RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get("id");
+
+        let dataset_id: i32 = sqlx::query(
+            "INSERT INTO dataset (short_name, name, description, units, geography_type)
+             VALUES ('src_cascade_test', 'Src Cascade Test', 't', 't', 1)
+             RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get("id");
+
+        let map_visualization_id: i32 = sqlx::query(
+            "INSERT INTO map_visualization
+                 (dataset, map_type, color_palette, scale_type, formatter_type, default_source)
+             VALUES ($1, 1, 1, 2, 3, $2)
+             RETURNING id",
+        )
+        .bind(dataset_id)
+        .bind(source_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get("id");
+
+        sqlx::query(
+            "INSERT INTO data (dataset, source, start_date, end_date, value, geography_type, id)
+             SELECT $1, $2, '2020-01-01', '2020-12-31', 1.0, geography_type, id
+             FROM geo_id LIMIT 1",
+        )
+        .bind(dataset_id)
+        .bind(source_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let app_state = web::Data::new(AppState {
+            connections: Mutex::new(0),
+            database: Arc::new(Database::from_pool(pool.clone())),
+        });
+        let app = test::init_service(App::new().app_data(app_state).configure(init_editor)).await;
+
+        let request = test::TestRequest::delete()
+            .uri(&format!("/data-source/{source_id}"))
+            .to_request();
+        let response = test::call_service(&app, request).await;
+        assert!(
+            response.status().is_success(),
+            "expected success, got {}",
+            response.status()
+        );
+
+        let sources: i64 = sqlx::query("SELECT COUNT(*) AS count FROM data_source WHERE id = $1")
+            .bind(source_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .get("count");
+        assert_eq!(sources, 0, "data_source row should be deleted");
+
+        let data_rows: i64 = sqlx::query("SELECT COUNT(*) AS count FROM data WHERE source = $1")
+            .bind(source_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .get("count");
+        assert_eq!(data_rows, 0, "data rows for the source should be deleted");
+
+        let default_source: Option<i32> =
+            sqlx::query("SELECT default_source FROM map_visualization WHERE id = $1")
+                .bind(map_visualization_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+                .get("default_source");
+        assert_eq!(
+            default_source, None,
+            "map visualization should remain with default_source cleared"
+        );
     }
 }

--- a/backend/src/dao/data_dao.rs
+++ b/backend/src/dao/data_dao.rs
@@ -380,10 +380,4 @@ impl<'c> Table<'c, Data> {
             .execute(&*self.pool)
             .await
     }
-
-    pub async fn delete_by_source(&self, source: i32) -> Result<PgQueryResult, sqlx::Error> {
-        sqlx::query!("DELETE FROM data WHERE source = $1", source)
-            .execute(&*self.pool)
-            .await
-    }
 }

--- a/backend/src/dao/data_source_dao.rs
+++ b/backend/src/dao/data_source_dao.rs
@@ -1,6 +1,7 @@
 use super::Table;
 use crate::model::data_source::{self, DataSource};
 use sqlx::postgres::PgQueryResult;
+use sqlx::{Acquire, Postgres};
 
 impl<'c> Table<'c, DataSource> {
     pub async fn all(&self) -> Result<Vec<DataSource>, sqlx::Error> {
@@ -71,9 +72,29 @@ impl<'c> Table<'c, DataSource> {
         .await;
     }
 
-    pub async fn delete(&self, id: i32) -> Result<PgQueryResult, sqlx::Error> {
+    pub async fn delete_cascading(&self, id: i32) -> Result<(), sqlx::Error> {
+        self.delete_cascading_in(&*self.pool, id).await
+    }
+
+    /// Runs inside `conn`: a pool gets its own transaction, an open
+    /// transaction nests via savepoint and the caller decides the final commit.
+    pub async fn delete_cascading_in<'a, A>(&self, conn: A, id: i32) -> Result<(), sqlx::Error>
+    where
+        A: Acquire<'a, Database = Postgres>,
+    {
+        let mut transaction = conn.begin().await?;
+        sqlx::query!(
+            "UPDATE map_visualization SET default_source = NULL WHERE default_source = $1",
+            id
+        )
+        .execute(&mut transaction)
+        .await?;
+        sqlx::query!("DELETE FROM data WHERE source = $1", id)
+            .execute(&mut transaction)
+            .await?;
         sqlx::query!("DELETE FROM data_source WHERE id = $1", id)
-            .execute(&*self.pool)
-            .await
+            .execute(&mut transaction)
+            .await?;
+        transaction.commit().await
     }
 }

--- a/backend/src/dao/data_source_dao.rs
+++ b/backend/src/dao/data_source_dao.rs
@@ -1,7 +1,6 @@
 use super::Table;
 use crate::model::data_source::{self, DataSource};
 use sqlx::postgres::PgQueryResult;
-use sqlx::{Acquire, Postgres};
 
 impl<'c> Table<'c, DataSource> {
     pub async fn all(&self) -> Result<Vec<DataSource>, sqlx::Error> {
@@ -73,16 +72,7 @@ impl<'c> Table<'c, DataSource> {
     }
 
     pub async fn delete_cascading(&self, id: i32) -> Result<(), sqlx::Error> {
-        self.delete_cascading_in(&*self.pool, id).await
-    }
-
-    /// Runs inside `conn`: a pool gets its own transaction, an open
-    /// transaction nests via savepoint and the caller decides the final commit.
-    pub async fn delete_cascading_in<'a, A>(&self, conn: A, id: i32) -> Result<(), sqlx::Error>
-    where
-        A: Acquire<'a, Database = Postgres>,
-    {
-        let mut transaction = conn.begin().await?;
+        let mut transaction = self.pool.begin().await?;
         sqlx::query!(
             "UPDATE map_visualization SET default_source = NULL WHERE default_source = $1",
             id

--- a/backend/src/dao/database.rs
+++ b/backend/src/dao/database.rs
@@ -52,7 +52,10 @@ pub struct Database<'c> {
 
 impl Database<'_> {
     pub async fn new(sql_url: &str) -> Database<'_> {
-        let pool = PgPool::connect(sql_url).await.unwrap();
+        Database::from_pool(PgPool::connect(sql_url).await.unwrap())
+    }
+
+    pub fn from_pool<'c>(pool: PgPool) -> Database<'c> {
         let pool = Arc::new(pool);
 
         Database {


### PR DESCRIPTION
## What changed

`DELETE /data-source/{id}` previously ran two separate auto-committed steps: delete the source's `data` rows, then delete the `data_source` row. If any `map_visualization.default_source` referenced the source, step 2 failed on the foreign key — but step 1 had already committed, permanently deleting the source's data while the source survived (reported as a misleading 404).

The handler now runs a single transaction: `UPDATE map_visualization SET default_source = NULL` for references to the source, delete its `data` rows, delete the `data_source` row, commit. All-or-nothing; errors now return 500 via the same `Error` wrapper pattern as `dataset_controller`.

## Test

New `#[sqlx::test]` integration test calls the real endpoint against an ephemeral migrated database. It was written first and failed on the old code with exactly the predicted FK-violation-as-404, and passes with the fix. Asserts: success response, source gone, its data gone, referencing map visualization survives with `default_source` NULL. Full backend suite green.

Also adds `Database::from_pool` so tests can build the DAO layer from the test pool.

Note: this and the other three cascade-fix PRs each add the identical `Database::from_pool` helper — whichever merges after the first will need a trivial rebase there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)