### PR TITLE
Fix tab deletion: unpublish its maps in the same transaction

### DIFF
--- a/backend/src/controller/data_category_controller.rs
+++ b/backend/src/controller/data_category_controller.rs
@@ -97,3 +97,75 @@ async fn update(
         Ok(_) => HttpResponse::Ok().finish(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dao::Database;
+    use actix_web::{test, App};
+    use sqlx::PgPool;
+    use std::sync::{Arc, Mutex};
+
+    #[sqlx::test]
+    async fn delete_removes_tab_and_unpublishes_its_maps(pool: PgPool) {
+        let tab_id: i32 = sqlx::query_scalar(
+            "INSERT INTO data_category (name, normalized, \"order\") VALUES ('cascade tab test', false, 99) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let dataset_id: i32 = sqlx::query_scalar(
+            "INSERT INTO dataset (short_name, name, description, units, geography_type) VALUES ('tab_cascade_test', 'Tab Cascade Test', 't', 't', 1) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let map_visualization_id: i32 = sqlx::query_scalar(
+            "INSERT INTO map_visualization (dataset, map_type, color_palette, scale_type, formatter_type) VALUES ($1, 1, 1, 2, 3) RETURNING id",
+        )
+        .bind(dataset_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO map_visualization_collection (map_visualization, category, \"order\") VALUES ($1, $2, 0)",
+        )
+        .bind(map_visualization_id)
+        .bind(tab_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let app_state = web::Data::new(AppState {
+            connections: Mutex::new(0),
+            database: Arc::new(Database::from_pool(pool.clone())),
+        });
+        let app = test::init_service(App::new().app_data(app_state).configure(init_editor)).await;
+        let request = test::TestRequest::delete()
+            .uri(&format!("/data-category/{}", tab_id))
+            .to_request();
+        let response = test::call_service(&app, request).await;
+        assert!(response.status().is_success());
+
+        let tabs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM data_category WHERE id = $1")
+            .bind(tab_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(tabs, 0);
+        let collection_rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM map_visualization_collection WHERE category = $1")
+                .bind(tab_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(collection_rows, 0);
+        let map_visualizations: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM map_visualization WHERE id = $1")
+                .bind(map_visualization_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(map_visualizations, 1);
+    }
+}

--- a/backend/src/dao/data_category_dao.rs
+++ b/backend/src/dao/data_category_dao.rs
@@ -37,9 +37,19 @@ impl<'c> Table<'c, DataCategory> {
     }
 
     pub async fn delete(&self, id: i32) -> Result<PgQueryResult, sqlx::Error> {
-        sqlx::query!("DELETE FROM data_category WHERE id = $1", id)
-            .execute(&*self.pool)
-            .await
+        let mut transaction = self.pool.begin().await?;
+        // Unpublish the category's map visualizations (the visualizations themselves are kept)
+        sqlx::query!(
+            "DELETE FROM map_visualization_collection WHERE category = $1",
+            id
+        )
+        .execute(&mut transaction)
+        .await?;
+        let result = sqlx::query!("DELETE FROM data_category WHERE id = $1", id)
+            .execute(&mut transaction)
+            .await?;
+        transaction.commit().await?;
+        Ok(result)
     }
 
     pub async fn last_order(&self) -> Result<i16, sqlx::Error> {

--- a/backend/src/dao/database.rs
+++ b/backend/src/dao/database.rs
@@ -52,7 +52,10 @@ pub struct Database<'c> {
 
 impl Database<'_> {
     pub async fn new(sql_url: &str) -> Database<'_> {
-        let pool = PgPool::connect(sql_url).await.unwrap();
+        Database::from_pool(PgPool::connect(sql_url).await.unwrap())
+    }
+
+    pub fn from_pool<'c>(pool: PgPool) -> Database<'c> {
         let pool = Arc::new(pool);
 
         Database {


### PR DESCRIPTION
## What changed

`DELETE /data-category/{id}` deleted only the `data_category` row. `map_visualization_collection.category` references it with no cascade, so deleting a tab that still had published map visualizations failed on the foreign key with a 500. (The editor UI only offers deletion for empty tabs, so this was latent — but the API was broken for non-empty tabs and racy against concurrent publishes.)

`Table<DataCategory>::delete` now runs one transaction: delete the tab's `map_visualization_collection` rows (which unpublishes those maps — the maps themselves are not deleted), then the tab row, then commit.

## Test

New `#[sqlx::test]` integration test calls the real endpoint against an ephemeral migrated database. Written first: it failed on the old code with the FK-driven 500, and passes with the fix. Asserts: success response, tab gone, its collection rows gone, the map visualization itself still present. Full backend suite green.

Also adds `Database::from_pool` so tests can build the DAO layer from the test pool.

Note: this and the other three cascade-fix PRs each add the identical `Database::from_pool` helper — whichever merges after the first will need a trivial rebase there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)