### PR TITLE
Fix map-visualization deletion: remove its collection rows in the same transaction

### DIFF
--- a/backend/src/controller/map_visualization_controller.rs
+++ b/backend/src/controller/map_visualization_controller.rs
@@ -203,3 +203,99 @@ async fn delete(id: web::Path<i32>, app_state: web::Data<AppState<'_>>) -> impl 
         Ok(_) => HttpResponse::Ok().finish(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{dao::Database, AppState};
+    use actix_web::{test, web, App};
+    use sqlx::{PgPool, Row};
+    use std::sync::{Arc, Mutex};
+
+    async fn count(pool: &PgPool, query: &str, id: i32) -> i64 {
+        sqlx::query(query)
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+            .get(0)
+    }
+
+    #[sqlx::test]
+    async fn delete_published_map_removes_collection_rows(pool: PgPool) {
+        let dataset_id: i32 = sqlx::query(
+            "INSERT INTO dataset (short_name, name, description, units, geography_type)
+            VALUES ('mapviz_cascade_test', 'Mapviz Cascade Test', 't', 't', 1) RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get(0);
+        let map_id: i32 = sqlx::query(
+            "INSERT INTO map_visualization (dataset, map_type, color_palette, scale_type, formatter_type)
+            VALUES ($1, 1, 1, 2, 3) RETURNING id",
+        )
+        .bind(dataset_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get(0);
+        let category_id: i32 = sqlx::query("SELECT id FROM data_category LIMIT 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .get(0);
+        sqlx::query(
+            "INSERT INTO map_visualization_collection (map_visualization, category, \"order\")
+            VALUES ($1, $2, 99)",
+        )
+        .bind(map_id)
+        .bind(category_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let app_state = web::Data::new(AppState {
+            connections: Mutex::new(0),
+            database: Arc::new(Database::from_pool(pool.clone())),
+        });
+        let app =
+            test::init_service(App::new().app_data(app_state).configure(super::init_editor)).await;
+        let request = test::TestRequest::delete()
+            .uri(&format!("/map-visualization/{map_id}"))
+            .to_request();
+        let response = test::call_service(&app, request).await;
+
+        assert!(
+            response.status().is_success(),
+            "delete failed with status {}",
+            response.status()
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT count(*) FROM map_visualization WHERE id = $1",
+                map_id
+            )
+            .await,
+            0
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT count(*) FROM map_visualization_collection WHERE map_visualization = $1",
+                map_id
+            )
+            .await,
+            0
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT count(*) FROM data_category WHERE id = $1",
+                category_id
+            )
+            .await,
+            1
+        );
+    }
+}

--- a/backend/src/dao/database.rs
+++ b/backend/src/dao/database.rs
@@ -52,7 +52,10 @@ pub struct Database<'c> {
 
 impl Database<'_> {
     pub async fn new(sql_url: &str) -> Database<'_> {
-        let pool = PgPool::connect(sql_url).await.unwrap();
+        Database::from_pool(PgPool::connect(sql_url).await.unwrap())
+    }
+
+    pub fn from_pool<'c>(pool: PgPool) -> Database<'c> {
         let pool = Arc::new(pool);
 
         Database {

--- a/backend/src/dao/map_visualization_dao.rs
+++ b/backend/src/dao/map_visualization_dao.rs
@@ -166,16 +166,27 @@ impl<'c> Table<'c, MapVisualization> {
         .await
     }
 
-    pub async fn delete(&self, id: i32) -> Result<PgQueryResult, sqlx::Error> {
+    pub async fn delete(&self, id: i32) -> Result<(), sqlx::Error> {
+        let mut transaction = self.pool.begin().await?;
+        sqlx::query!(
+            "DELETE FROM map_visualization_collection WHERE map_visualization = $1",
+            id
+        )
+        .execute(&mut transaction)
+        .await?;
         sqlx::query!("DELETE FROM map_visualization WHERE id = $1", id)
-            .execute(&*self.pool)
-            .await
+            .execute(&mut transaction)
+            .await?;
+        transaction.commit().await
     }
 
     pub async fn delete_by_dataset(&self, dataset_id: i32) -> Result<PgQueryResult, sqlx::Error> {
-        sqlx::query!("DELETE FROM map_visualization WHERE dataset = $1", dataset_id)
-            .execute(&*self.pool)
-            .await
+        sqlx::query!(
+            "DELETE FROM map_visualization WHERE dataset = $1",
+            dataset_id
+        )
+        .execute(&*self.pool)
+        .await
     }
 
     pub async fn get_by_dataset(


### PR DESCRIPTION
## What changed

`DELETE /map-visualization/{id}` deleted only the `map_visualization` row. `map_visualization_collection.map_visualization` references it with no cascade, so deleting a *published* map failed on the foreign key with a 500. (The editor UI only offers Delete on drafts, which have no collection rows, so this was latent — but the API was broken for published maps.)

`Table<MapVisualization>::delete` now runs one transaction: delete the map's `map_visualization_collection` rows (unpublishing it everywhere), then the map row, then commit.

## Test

New `#[sqlx::test]` integration test calls the real endpoint against an ephemeral migrated database, deleting a published map. Written first: it failed on the old code with the FK-driven 500, and passes with the fix. Asserts: success response, map gone, its collection rows gone, the tab still exists. Full backend suite green.

Also adds `Database::from_pool` so tests can build the DAO layer from the test pool.

Note: this and the other three cascade-fix PRs each add the identical `Database::from_pool` helper — whichever merges after the first will need a trivial rebase there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)