### PR TITLE
Make dataset deletion cascade atomic

### DIFF
--- a/backend/src/controller/dataset_controller.rs
+++ b/backend/src/controller/dataset_controller.rs
@@ -47,30 +47,129 @@ async fn get_all(app_state: web::Data<AppState<'_>>) -> impl Responder {
 #[delete("/dataset/{id}")]
 async fn delete(id: web::Path<i32>, app_state: web::Data<AppState<'_>>) -> Result<String, Error> {
     let id = id.into_inner();
-    app_state
+    // Delete the dataset and everything that references it in one transaction,
+    // so a failing step can't leave the dataset partially deleted
+    let mut tx = app_state
         .database
-        .map_visualization_collection
-        .delete_by_dataset(id)
+        .dataset
+        .pool
+        .begin()
         .await
         .map_err(Error)?;
-    app_state
-        .database
-        .map_visualization
-        .delete_by_dataset(id)
+    sqlx::query!(
+        "DELETE FROM map_visualization_collection
+        USING map_visualization
+        WHERE map_visualization_collection.map_visualization = map_visualization.id
+        AND map_visualization.dataset = $1",
+        id
+    )
+    .execute(&mut tx)
+    .await
+    .map_err(Error)?;
+    sqlx::query!("DELETE FROM map_visualization WHERE dataset = $1", id)
+        .execute(&mut tx)
         .await
         .map_err(Error)?;
-    app_state
-        .database
-        .data
-        .delete_by_dataset(id)
+    sqlx::query!("DELETE FROM data WHERE dataset = $1", id)
+        .execute(&mut tx)
         .await
         .map_err(Error)?;
-    app_state.database.dataset.delete(id).await.map_err(Error)?;
+    sqlx::query!("DELETE FROM dataset WHERE id = $1", id)
+        .execute(&mut tx)
+        .await
+        .map_err(Error)?;
+    tx.commit().await.map_err(Error)?;
     Ok("deleted".to_string())
 }
 
 #[derive(Debug, Display)]
 struct Error(sqlx::Error);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dao::Database;
+    use actix_web::{test, App};
+    use sqlx::PgPool;
+    use std::sync::{Arc, Mutex};
+
+    async fn insert_dataset(pool: &PgPool, short_name: &str, name: &str) -> i32 {
+        sqlx::query_scalar(
+            "INSERT INTO dataset (short_name, name, description, units, geography_type)
+            VALUES ($1, $2, 't', 't', 1) RETURNING id",
+        )
+        .bind(short_name)
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    async fn insert_map_visualization(pool: &PgPool, id: i32, dataset: i32) {
+        sqlx::query(
+            "INSERT INTO map_visualization (id, dataset, map_type, color_palette, scale_type, formatter_type)
+            VALUES ($1, $2, 1, 1, 2, 3)",
+        )
+        .bind(id)
+        .bind(dataset)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn count(pool: &PgPool, query: &str, id: i32) -> i64 {
+        sqlx::query_scalar(query)
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    #[sqlx::test]
+    async fn delete_removes_only_the_datasets_own_map_visualizations(pool: PgPool) {
+        let dataset = insert_dataset(&pool, "ds_cascade_test", "Ds Cascade Test").await;
+        let bystander_dataset = insert_dataset(&pool, "ds_bystander", "Ds Bystander").await;
+        insert_map_visualization(&pool, dataset + 1000, dataset).await;
+        // A map visualization whose id collides with the deleted dataset's id,
+        // to catch a cascade that filters map visualizations by id instead of dataset
+        insert_map_visualization(&pool, dataset, bystander_dataset).await;
+
+        let app_state = web::Data::new(AppState {
+            connections: Mutex::new(0),
+            database: Arc::new(Database::from_pool(pool.clone())),
+        });
+        let app = test::init_service(App::new().app_data(app_state).configure(init_editor)).await;
+
+        let request = test::TestRequest::delete()
+            .uri(&format!("/dataset/{dataset}"))
+            .to_request();
+        let response = test::call_service(&app, request).await;
+
+        assert!(response.status().is_success());
+        assert_eq!(
+            count(&pool, "SELECT count(*) FROM dataset WHERE id = $1", dataset).await,
+            0
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT count(*) FROM map_visualization WHERE dataset = $1",
+                dataset
+            )
+            .await,
+            0
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT count(*) FROM map_visualization WHERE id = $1",
+                dataset
+            )
+            .await,
+            1
+        );
+    }
+}
 
 impl actix_web::error::ResponseError for Error {
     fn error_response(&self) -> HttpResponse {

--- a/backend/src/dao/database.rs
+++ b/backend/src/dao/database.rs
@@ -52,7 +52,10 @@ pub struct Database<'c> {
 
 impl Database<'_> {
     pub async fn new(sql_url: &str) -> Database<'_> {
-        let pool = PgPool::connect(sql_url).await.unwrap();
+        Database::from_pool(PgPool::connect(sql_url).await.unwrap())
+    }
+
+    pub fn from_pool<'c>(pool: PgPool) -> Database<'c> {
         let pool = Arc::new(pool);
 
         Database {


### PR DESCRIPTION
## What changed

`DELETE /dataset/{id}` runs a four-step cascade (collection rows → map visualizations → data → dataset) as separate auto-committed statements. If a later step failed, the earlier steps had already committed: the dataset's maps were silently unpublished and its data rows permanently deleted while the dataset and maps remained. The `WHERE`-clause bug fixed in #108 demonstrated exactly this damage pattern.

The handler now runs all four deletes in a single transaction and commits at the end — all-or-nothing.

## Test

New `#[sqlx::test]` integration test calls the real endpoint against an ephemeral migrated database, with fixtures designed to catch the #108 regression class: a draft map whose id differs from the dataset id (must be deleted) and a bystander map of another dataset whose id equals the deleted dataset's id (must survive). Verified test-first by temporarily reintroducing the #108 bug — the test fails there and passes on the fixed, transactional code. Full backend suite green.

A dedicated rollback/atomicity test was considered and skipped: the only FK children of `dataset` are handled inside the transaction, so no realistic mid-cascade failure can be constructed without contrived failure injection.

Also adds `Database::from_pool` so tests can build the DAO layer from the test pool.

Note: this and the other three cascade-fix PRs each add the identical `Database::from_pool` helper — whichever merges after the first will need a trivial rebase there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)