### PR TITLE
Serve map visualizations whose dataset has no data

### DIFF
--- a/backend/src/controller/map_visualization_controller.rs
+++ b/backend/src/controller/map_visualization_controller.rs
@@ -1,5 +1,5 @@
 use crate::{
-    model::map_visualization::{Creator, Error, Json, JsonPatch, MapVisualization, Patch},
+    model::map_visualization::{Creator, Json, JsonPatch, MapVisualization, Patch},
     AppState,
 };
 use actix_web::{delete, get, patch, post, web, HttpResponse, Responder};
@@ -38,20 +38,8 @@ async fn get_map_visualization_model(
         .database
         .data_source
         .by_dataset(map_visualization.dataset);
-    let result = try_join(sources_and_dates, data_sources).await;
-    match result {
-        Err(e) => Err(e),
-        Ok((source_and_dates, data_sources)) => {
-            if data_sources.is_empty() {
-                return Err(sqlx::Error::Decode(Box::new(Error {
-                    message: format!(
-                        "No sources and dates found for map visualization {map_visualization:#?}",
-                    ),
-                })));
-            }
-            Ok(Json::new(map_visualization, source_and_dates, data_sources))
-        }
-    }
+    let (source_and_dates, data_sources) = try_join(sources_and_dates, data_sources).await?;
+    Ok(Json::new(map_visualization, source_and_dates, data_sources))
 }
 
 #[get("/map-visualization/{id}")]
@@ -201,5 +189,115 @@ async fn delete(id: web::Path<i32>, app_state: web::Data<AppState<'_>>) -> impl 
     match result {
         Err(_) => HttpResponse::InternalServerError().finish(),
         Ok(_) => HttpResponse::Ok().finish(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::controller::data_source_controller;
+    use crate::dao::Database;
+    use actix_web::{test, App};
+    use sqlx::PgPool;
+    use std::sync::{Arc, Mutex};
+
+    #[sqlx::test]
+    async fn serves_map_visualization_whose_only_source_was_deleted(pool: PgPool) {
+        let source_id = sqlx::query!(
+            "INSERT INTO data_source (name, description, link)
+             VALUES ('zombie test', 'test source', 'https://example.com')
+             RETURNING id"
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .id;
+
+        let dataset_id = sqlx::query!(
+            "INSERT INTO dataset (short_name, name, description, units, geography_type)
+             VALUES ('zombie_test', 'Zombie Test', 't', 't', 1)
+             RETURNING id"
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .id;
+
+        let map_visualization_id = sqlx::query!(
+            "INSERT INTO map_visualization
+                 (dataset, map_type, color_palette, scale_type, formatter_type, default_source)
+             VALUES ($1, 1, 1, 2, 3, $2)
+             RETURNING id",
+            dataset_id,
+            source_id
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .id;
+
+        sqlx::query!(
+            "INSERT INTO data (dataset, source, start_date, end_date, value, geography_type, id)
+             SELECT $1, $2, '2020-01-01', '2020-12-31', 1.0, geography_type, id
+             FROM geo_id LIMIT 1",
+            dataset_id,
+            source_id
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query!(
+            r#"INSERT INTO map_visualization_collection (map_visualization, category, "order")
+             SELECT $1, MIN(id)::int2, int2(32000) FROM data_category"#,
+            map_visualization_id
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let app_state = web::Data::new(AppState {
+            connections: Mutex::new(0),
+            database: Arc::new(Database::from_pool(pool.clone())),
+        });
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state)
+                .configure(init)
+                .configure(data_source_controller::init_editor),
+        )
+        .await;
+
+        let request = test::TestRequest::delete()
+            .uri(&format!("/data-source/{source_id}"))
+            .to_request();
+        let status = test::call_service(&app, request).await.status();
+        assert!(status.is_success(), "delete failed: {}", status);
+
+        let request = test::TestRequest::get()
+            .uri("/map-visualization?include_drafts=false&geography_type=1")
+            .to_request();
+        let response = test::call_service(&app, request).await;
+        let status = response.status();
+        assert!(status.is_success(), "expected success, got {}", status);
+        let body: serde_json::Value = test::read_body_json(response).await;
+        let visualization = body
+            .as_object()
+            .unwrap()
+            .values()
+            .find_map(|tab| tab.get(map_visualization_id.to_string()))
+            .expect("visualization with a deleted source should still be listed");
+        assert_eq!(visualization["sources"], serde_json::json!({}));
+        assert_eq!(visualization["default_source"], serde_json::Value::Null);
+
+        let request = test::TestRequest::get()
+            .uri(&format!("/map-visualization/{map_visualization_id}"))
+            .to_request();
+        let status = test::call_service(&app, request).await.status();
+        assert!(
+            status.is_success(),
+            "single visualization endpoint failed: {}",
+            status
+        );
     }
 }


### PR DESCRIPTION
## Problem

Deleting a data source that was the only source for a dataset (e.g. ERA5 for Water Stress) leaves its map visualizations with zero derivable sources. `get_map_visualization_model` treated that as a hard error ("No sources and dates found…"), and `by_tab` propagates errors with `?` — so **one** such visualization made `GET /map-visualization` return 500, taking down the whole homepage and the editor's listing (which uses the same code path with `include_drafts=true`). This happened in production on 2026-08-28 after deleting the ERA5 source.

## Fix

Serve the visualization instead of erroring: `get_map_visualization_model` now returns the `Json` model with an empty `sources` map and empty `date_ranges_by_source`, in both the listing and single-visualization endpoints. The visualization stays visible in the editor and on the website; its hand-tuned config survives, and it comes back to life when data is re-uploaded for its dataset.

## Regression test

An end-to-end `#[sqlx::test]` reproduces the incident: seed a published visualization whose dataset has one source, delete that source through the real `DELETE /data-source/{id}` endpoint, then assert `GET /map-visualization?include_drafts=false&geography_type=1` returns 200 with the visualization present, `sources` empty, and `default_source` null — and that `GET /map-visualization/{id}` also returns 200.

## Notes

- **Stacked on #109** (base branch `claude/fix-data-source-delete-cascade`) — it reuses the delete-cascade endpoint and `Database::from_pool` test setup from that PR. Merge #109 first, then retarget this to `main`.
- **Pairs with the in-flight frontend fix** for zero-source visualizations (`getDefaultSource`/`getDefaultDateRange` non-null assertions in `frontend/src/MapVisualization.ts`, `appSlice.ts`): with this backend change alone, the client now receives visualizations with empty `sources` and must render them gracefully instead of asserting. Land both together.
- The unused `model::map_visualization::Error` import is dropped; the struct itself is still used elsewhere in the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)